### PR TITLE
Change "async" keyword to "asynchronous"

### DIFF
--- a/BB2_EP_PANEL.py
+++ b/BB2_EP_PANEL.py
@@ -293,7 +293,7 @@ def scenewideEP(animation):
             f.close()
             command = panel.quotedPath(homePath + "tmp" + os.sep + "apbs.exe") + " " + panel.quotedPath(
                 homePath + "tmp" + os.sep + "scenewide.in")
-        p = panel.launch(exeName=command, async=True)
+        p = panel.launch(exeName=command, asynchronous=True)
         print("APBS Ok")
 
         # sync

--- a/BB2_MLP_PANEL.py
+++ b/BB2_MLP_PANEL.py
@@ -310,7 +310,7 @@ def mlp(tID, force):
                 pyPath = "python"
             command = "%s %s -i %s -m %s -s %f -o %s -v" % (panel.quotedPath(pyPath), panel.quotedPath(homePath + "bin" + os.sep + "pyMLP-1.0" + os.sep + "pyMLP.py"), panel.quotedPath(homePath + "tmp" + os.sep + NamePDBMLP(tID) + os.sep + "tmp.pdb"), method, spacing, panel.quotedPath(homePath + "tmp" + os.sep + NamePDBMLP(tID) + os.sep + "tmp.dx"))
 
-            p = panel.launch(exeName=command, async=True)
+            p = panel.launch(exeName=command, asynchronous=True)
 
             print("PyMLP command succeded")
             panel.surface(sPid=tID, optName=namemlp)

--- a/BB2_NMA_PANEL.py
+++ b/BB2_NMA_PANEL.py
@@ -130,18 +130,18 @@ def computeNormalModeTrajectories():
         if opSystem == "linux":
             command = "chmod 755 %s" % (panel.quotedPath(homePath + "bin" + os.sep + "nma" + os.sep + "nma.py"))
             command = panel.quotedPath(command)
-            p = panel.launch(exeName=command, async=False)
+            p = panel.launch(exeName=command, asynchronous=False)
         elif opSystem == "darwin":
             command = "chmod 755 %s" % (panel.quotedPath(homePath + "bin" + os.sep + "nma" + os.sep + "nma.py"))
             command = panel.quotedPath(command)
-            p = panel.launch(exeName=command, async=False)
+            p = panel.launch(exeName=command, asynchronous=False)
         else:
             pyPath = "python"
         command = "%s %s -i %s -o %s -m %d -r %f -n %d %s " % (
             panel.quotedPath(pyPath), panel.quotedPath(homePath + "bin" + os.sep + "nma" + os.sep + "nma.py"),
             panel.quotedPath(inputpath),
             panel.quotedPath(outputpath), mode, rmsd, nbconfiguration, struct)
-        p = panel.launch(exeName=command, async=False)
+        p = panel.launch(exeName=command, asynchronous=False)
         bpy.context.scene.BBImportPath = outputpath
         PDBIMPORT.importPreview()
     else:

--- a/BB2_PANEL_VIEW.py
+++ b/BB2_PANEL_VIEW.py
@@ -410,7 +410,7 @@ def quotedPath(stringaInput):
 
 
 # launch app in separate process, for better performance on multithreaded computers
-def launch(exeName, async=False):
+def launch(exeName, asynchronous=False):
     # try to hide window (does not work recursively)
     if opSystem == "linux":
         istartupinfo = None


### PR DESCRIPTION
Hi Pablo, great work with this addon!

I installed BioBlender for the first time today on my Linux machine (Ubuntu 20.04.1 LTS x86_64 ) running Python 3.8.5. I realize you identified Python 3.5.3 as a dependency but I think I came across an issue that a quick fix will allow for people running more current versions of Python to use BioBlender. 

When I first attempted to import BioBlender I got a the syntax error below

```
def launch(exeName, async=False):  
                    ^
SyntaxError: invalid syntax
```
I think this may be because `async` is now a keyword but I am not 100% sure. I do know that refactoring `async` to `asynchronous` got BioBlender working for me so I'd thought I'd bring it to your attention. 

Thanks and be well!